### PR TITLE
feat(api): use Swagger UI OAuth2 password login

### DIFF
--- a/api/src/modules/ktags/contract.ts
+++ b/api/src/modules/ktags/contract.ts
@@ -21,7 +21,7 @@ export const ktagsContract = c.router({
   },
   updateLabel: {
     method: "PATCH",
-    path: "/api/me/ktags/:tag_id/label",
+    path: "/api/me/ktags/label/:tag_id",
     pathParams: z.object({ tag_id: z.string() }),
     body: UpdateKtagLabelBodySchema,
     responses: { 200: KtagSchema, 401: ErrorSchema, 404: ErrorSchema },

--- a/api/src/plugins/auth.ts
+++ b/api/src/plugins/auth.ts
@@ -44,6 +44,22 @@ const auth = betterAuth({
 
 export type Session = typeof auth.$Infer.Session;
 
+function sendOauthTokenError(
+  reply: FastifyReply,
+  statusCode: number,
+  error: string,
+  errorDescription: string,
+) {
+  return reply
+    .status(statusCode)
+    .header("cache-control", "no-store")
+    .header("pragma", "no-cache")
+    .send({
+      error,
+      error_description: errorDescription,
+    });
+}
+
 // ── Fastify type augmentation ───────────────────────────────────────────────
 declare module "fastify" {
   interface FastifyRequest {
@@ -110,6 +126,75 @@ export default fp(
         request.session = session;
       },
     );
+
+    fastify.route({
+      method: "POST",
+      url: "/api/docs/oauth/token",
+      schema: { hide: true },
+      async handler(request, reply) {
+        const body = (request.body ?? {}) as Record<string, unknown>;
+        const grantType =
+          typeof body.grant_type === "string" ? body.grant_type : undefined;
+        const username =
+          typeof body.username === "string" ? body.username.trim() : undefined;
+        const password =
+          typeof body.password === "string" ? body.password : undefined;
+        const scope = typeof body.scope === "string" ? body.scope : undefined;
+
+        if (grantType !== "password") {
+          return sendOauthTokenError(
+            reply,
+            400,
+            "unsupported_grant_type",
+            "Only the OAuth2 password grant is supported for Swagger UI.",
+          );
+        }
+
+        if (!username || !password) {
+          return sendOauthTokenError(
+            reply,
+            400,
+            "invalid_request",
+            "username and password are required.",
+          );
+        }
+
+        try {
+          const data = await auth.api.signInEmail({
+            body: {
+              email: username,
+              password,
+              rememberMe: true,
+            },
+          });
+
+          if (!data.token) {
+            return sendOauthTokenError(
+              reply,
+              500,
+              "server_error",
+              "No bearer token was returned.",
+            );
+          }
+
+          return reply
+            .header("cache-control", "no-store")
+            .header("pragma", "no-cache")
+            .send({
+              access_token: data.token,
+              token_type: "Bearer",
+              ...(scope ? { scope } : {}),
+            });
+        } catch {
+          return sendOauthTokenError(
+            reply,
+            400,
+            "invalid_grant",
+            "Invalid email or password.",
+          );
+        }
+      },
+    });
 
     // Forward all better-auth routes (cookie-based auth, etc.)
     fastify.route({

--- a/api/src/plugins/swagger.ts
+++ b/api/src/plugins/swagger.ts
@@ -6,17 +6,22 @@ import { generateOpenApi } from "@ts-rest/open-api";
 import { contract } from "../api.contract.js";
 
 const openApiDocument = generateOpenApi(
-  contract, 
+  contract,
   {
     info: { title: "Klariti API", description: "Klariti OS REST API", version: "1.0.0" },
     servers: [{ url: "/", description: "Current server" }],
     components: {
       securitySchemes: {
         bearerAuth: {
-          type: "http",
-          scheme: "bearer",
+          type: "oauth2",
           description:
-            "Sign in via POST /api/sign-in, copy the token from the response, then paste it here.",
+            "Use Swagger UI's built-in password flow to sign in. The username field should be your Klariti account email.",
+          flows: {
+            password: {
+              tokenUrl: "/api/docs/oauth/token",
+              scopes: {},
+            },
+          },
         },
       },
     },
@@ -44,6 +49,9 @@ export default fp(
         docExpansion: "list",
         deepLinking: true,
         persistAuthorization: true,
+      },
+      theme: {
+        title: "Klariti API Docs",
       },
     });
   },

--- a/api/tests/swagger.test.ts
+++ b/api/tests/swagger.test.ts
@@ -1,0 +1,76 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import swaggerPlugin from "../src/plugins/swagger.js";
+import { buildApp } from "./helpers/build-app.js";
+import { signUp, testEmail } from "./helpers/auth.js";
+import { cleanupTestUsers } from "./helpers/cleanup.js";
+
+const app = buildApp();
+app.register(swaggerPlugin);
+
+beforeAll(async () => {
+  await cleanupTestUsers();
+  await app.ready();
+});
+
+afterAll(async () => {
+  await cleanupTestUsers();
+  await app.close();
+});
+
+describe("Swagger docs auth flow", () => {
+  it("serves the default Swagger UI shell without the custom helper assets", async () => {
+    const response = await app.inject({
+      method: "GET",
+      url: "/docs",
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.headers["content-type"]).toContain("text/html");
+    expect(response.body).toContain("<title>Klariti API Docs</title>");
+    expect(response.body).not.toContain("klariti-docs-auth");
+  });
+
+  it("documents bearer auth as Swagger's built-in OAuth2 password flow", async () => {
+    const response = await app.inject({
+      method: "GET",
+      url: "/docs/json",
+    });
+
+    expect(response.statusCode).toBe(200);
+
+    const body = response.json();
+    expect(body.components.securitySchemes.bearerAuth.type).toBe("oauth2");
+    expect(body.components.securitySchemes.bearerAuth.flows.password.tokenUrl).toBe(
+      "/api/docs/oauth/token",
+    );
+    expect(body.components.securitySchemes.bearerAuth.flows.password.scopes).toEqual({});
+  });
+
+  it("exchanges username and password for a bearer token at the Swagger token endpoint", async () => {
+    const email = testEmail("swagger-oauth");
+    const password = "password123";
+
+    await signUp(app, email, "Swagger OAuth", password);
+
+    const response = await app.inject({
+      method: "POST",
+      url: "/api/docs/oauth/token",
+      headers: {
+        "content-type": "application/x-www-form-urlencoded",
+      },
+      payload: new URLSearchParams({
+        grant_type: "password",
+        username: email,
+        password,
+      }).toString(),
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.headers["cache-control"]).toBe("no-store");
+    expect(response.headers["pragma"]).toBe("no-cache");
+
+    const body = response.json();
+    expect(body.access_token).toBeTypeOf("string");
+    expect(body.token_type).toBe("Bearer");
+  });
+});


### PR DESCRIPTION
## Summary
- switch the Swagger security scheme to OAuth2 password flow so the built-in Authorize modal can accept credentials
- add a hidden Swagger token endpoint that adapts the existing Better Auth email/password sign-in to OAuth2 token semantics
- add focused Swagger auth tests covering the OpenAPI scheme and token exchange

## Testing
- pnpm --filter @klariti/api exec vitest run tests/swagger.test.ts
- pnpm --filter @klariti/api check-types